### PR TITLE
🛠️ Fix UpdateUser

### DIFF
--- a/internal/adapter/handler/http/user.go
+++ b/internal/adapter/handler/http/user.go
@@ -194,13 +194,13 @@ func (uh *UserHandler) UpdateUser(ctx *gin.Context) {
 		Role:     req.Role,
 	}
 
-	_, err = uh.svc.UpdateUser(ctx, &user)
+	updatedUser, err := uh.svc.UpdateUser(ctx, &user)
 	if err != nil {
 		handleError(ctx, err)
 		return
 	}
 
-	rsp := newUserResponse(&user)
+	rsp := newUserResponse(updatedUser)
 
 	handleSuccess(ctx, rsp)
 }

--- a/internal/core/service/user.go
+++ b/internal/core/service/user.go
@@ -163,7 +163,7 @@ func (us *UserService) UpdateUser(ctx context.Context, user *domain.User) (*doma
 
 	user.Password = hashedPassword
 
-	_, err = us.repo.UpdateUser(ctx, user)
+	updatedUser, err := us.repo.UpdateUser(ctx, user)
 	if err != nil {
 		if err == domain.ErrConflictingData {
 			return nil, err
@@ -193,7 +193,7 @@ func (us *UserService) UpdateUser(ctx context.Context, user *domain.User) (*doma
 		return nil, domain.ErrInternal
 	}
 
-	return user, nil
+	return updatedUser, nil
 }
 
 // DeleteUser deletes a user by ID


### PR DESCRIPTION
If we update only the username, then other fields may return empty (example: email) or which are the default. Therefore, it is best to return the updated user, which is stored in the database